### PR TITLE
Lunar linecol gradient

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Ready to Print Monthly and Yearly Calendars Made with 'ggplot2'
 Version: 1.1
 Authors@R: c(
   person("José Carlos", "Soage González", email = "jsoage@uvigo.es", role = c("aut", "cre")),
-   person("Natalia", "Pérez Veiga", email = "naperez@uvigo.es", role = "aut")
+  person("Natalia", "Pérez Veiga", email = "naperez@uvigo.es", role = "aut"),
+  person("Marcel", "Schilling", email = "foss@mschilli.com", role = "ctb")
   )
 Description: Contains the function calendR() for creating fully customizable monthly and yearly calendars (colors, fonts, formats, ...) and even heatmap calendars. In addition, it allows saving the calendars in ready to print A4 format PDF files.
 Imports: ggplot2, dplyr, forcats, suncalc, ggimage, gggibbous

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,4 +12,4 @@ Encoding: UTF-8
 URL: https://r-coder.com/, https://r-coder.com/calendar-plot-r/
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 R-Coder
+Copyright (c) 2020, 2021 R-Coder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/man/calendR.Rd
+++ b/man/calendR.Rd
@@ -48,6 +48,7 @@ calendR(
   bg.col = "white",
   bg.img = "",
   margin = 1,
+  ncol,
   lunar = FALSE,
   lunar.col = "gray60",
   lunar.size = 7,
@@ -142,6 +143,8 @@ calendR(
 \item{bg.img}{Character string containing the URL or the local directory of a image to be used as background.}
 
 \item{margin}{Numeric. Allows controlling the margin of the calendar.}
+
+\item{ncol}{Numeric. Controls the number of columns of the yearly calendar. Overrides the default values for "landscape" and "portrait" orientation.}
 
 \item{lunar}{Boolean. If \code{TRUE}, draws the lunar phases. Only available for monthly calendars.}
 

--- a/man/calendR.Rd
+++ b/man/calendR.Rd
@@ -52,6 +52,12 @@ calendR(
   lunar = FALSE,
   lunar.col = "gray60",
   lunar.size = 7,
+  lunar.line.gradient = FALSE,
+  lunar.linecol.new = "grey60",
+  lunar.linecol.waxing = "green",
+  lunar.linecol.full = "yellow",
+  lunar.linecol.waning = "red",
+  lunar.linecol.old = lunar.linecol.new,
   pdf = FALSE,
   doc_name = "",
   papersize = "A4"
@@ -152,6 +158,18 @@ calendR(
 
 \item{lunar.size}{If \code{lunar = TRUE}, is the size of the representation of the moons.}
 
+\item{lunar.line.gradient}{Boolean. If \code{TRUE} (and \code{lunar = TRUE}), colors the outline of the lunar phases by phase progression. Defaults to \code{FALSE}.}
+
+\item{lunar.linecol.new}{If \code{lunar.line.gradient = TRUE} (and \code{lunar = TRUE}), is the color of the outline of the lunar phase at new moon. Defaults to \code{"grey60"}.}
+
+\item{lunar.linecol.waxing}{If \code{lunar.line.gradient = TRUE} (and \code{lunar = TRUE}), is the color of the outline of the lunar phase at the first quarter. Defaults to \code{"green"}.}
+
+\item{lunar.linecol.full}{If \code{lunar.line.gradient = TRUE} (and \code{lunar = TRUE}), is the color of the outline of the lunar phase at full moon. Defaults to \code{"yellow"}.}
+
+\item{lunar.linecol.waning}{If \code{lunar.line.gradient = TRUE} (and \code{lunar = TRUE}), is the color of the outline of the lunar phase at the third moon. Defaults to \code{"red"}.}
+
+\item{lunar.linecol.old}{If \code{lunar.line.gradient = TRUE} (and \code{lunar = TRUE}), is the color of the outline of the lunar phase at old moon (i.e. just before new moon). Defaults to \code{lunar.linecol.new}.}
+
 \item{pdf}{Boolean. If \code{TRUE}, saves the calendar in the working directory in A4 format.}
 
 \item{doc_name}{If \code{pdf = TRUE}, is the name of the generated file (without the file extension). If not specified, creates files of the format: \code{Calendar_year.pdf} for yearly calendars and \code{Calendar_month_year.pdf} for monthly calendars.}
@@ -180,5 +198,6 @@ invisible(sapply(1:12 , function(i) calendR(month = i, pdf = TRUE,
 \itemize{
 \item{Soage González, José Carlos.}
 \item{Maintainer: José Carlos Soage González. \email{jsoage@uvigo.es}}
+\item{Contributor: Marcel Schilling. \email{foss@mschilli.com}}
 }
 }


### PR DESCRIPTION
This PR adds new parameters that allow coloring of the moon phase outlines by a gradient indicating the moon's progression:

```R
# devtools::install_github("mschilli87/calendR@lunar-linecol-gradient")
library(calendR)

# Default remains unchanged.
calendR(year = 2021, month = 12, lunar = TRUE)
```

![default](https://user-images.githubusercontent.com/12913701/146657583-c7a26c6e-079a-484f-8478-b187c3f96ad6.png)


```R
# Default gradient colors phases smoothly in a circular fashion:
calendR(year = 2021, month = 12, lunar = TRUE, lunar.line.gradient = TRUE)
```
![gradient](https://user-images.githubusercontent.com/12913701/146657589-e1d43e0e-7eff-4991-a9ac-916a2479b6bd.png)

```R
# Parameters allow complex custom coloring:
calendR(year = 2021, month = 12, lunar = TRUE, lunar.line.gradient = TRUE,
        low.col = "yellow", lunar.col = "orange",
        lunar.linecol.new = "black", lunar.linecol.waxing = "purple",
        lunar.linecol.full = "blue", lunar.linecol.waning = "cyan",
        lunar.linecol.old = "green")
```

![custom](https://user-images.githubusercontent.com/12913701/146657694-a57bd4a8-3a3e-46e1-a316-38a6d43bfb95.png)

Note that `roxygen2::roxigenise` picked up [some unrelated documentation changes](https://github.com/R-CoderDotCom/calendR/commit/4d12ae76146857aa15d98e3bda81578b60923162) I commited these separately for clarity.

Please let me know if you prefer any changes to my suggestion. 