### PR TITLE
[bugfix] Only compare matching length vectors

### DIFF
--- a/R/calendR.R
+++ b/R/calendR.R
@@ -289,8 +289,7 @@ calendR <- function(year = format(Sys.Date(), "%Y"),
   if(is.character(special.days)) {
 
     if(length(special.days) != length(dates)){
-
-      if(special.days != "weekend") {
+      if(length(special.days) != 1L || special.days != "weekend") {
         stop("special.days must be a numeric vector, a character vector of the length of the number of days of the year or month or 'weekend'")
       } else {
         wend <- FALSE
@@ -372,7 +371,7 @@ calendR <- function(year = format(Sys.Date(), "%Y"),
         if (length(special.days) == length(dates)) {
           fills <- special.days
         } else {
-          if (special.days == "weekend") {
+          if (length(special.days) == 1L && special.days == "weekend") {
             fills <- t2$weekend
           }
         }
@@ -422,7 +421,7 @@ calendR <- function(year = format(Sys.Date(), "%Y"),
         if (length(special.days) == length(dates)) {
           fills <- special.days
         } else {
-          if (special.days == "weekend") {
+          if (length(special.days) == 1L && special.days == "weekend") {
             fills <- t2$weekend
           }
         }


### PR DESCRIPTION
Ensure `length(special.days) == 1L` before comparing to `"weekends"`. This is requried for newer versions of R.

As far as I can tell, this does not limit any functionality, but masks the informative error message when specifying the wrong number of days (i.e. 365 for a leap year) with an uninformative one.

This commit fixes issue #30.

@R-CoderDotCom: I submitted calendRio v.02.1 containing this fix to CRAN and thought I offer it upstream as well.